### PR TITLE
fix preview for archive and (custom) post

### DIFF
--- a/plugins/WordsbyCore/previews/post-preview-button.php
+++ b/plugins/WordsbyCore/previews/post-preview-button.php
@@ -49,24 +49,20 @@ function custom_preview_page_link($link) {
 
 	$assigned_template = get_post_meta($id, "_wp_page_template", true);
 	
-	if ($is_archive) {
-		$assigned_template = "archive/$archive_post_type";
-	} elseif ($assigned_template === "") {
-		$assigned_template = "single/$post_type";
-	}
-
 	$rest_base = !empty($obj->rest_base) ? $obj->rest_base : $obj->name;
-	
-	if ($assigned_template === 'default' && !$is_archive) {
-		$desired_template = "single/$post_type";
-	} else {
-		$desired_template = $assigned_template;
-	}
 
-	if (array_key_exists($desired_template, $available_templates)) {
-		$available_template = $desired_template;
-	} else {
-		$available_template = $default_template;
+	if($post_type == 'page'){
+
+		if (array_key_exists($assigned_template, $available_templates)) {
+			$available_template = $assigned_template;
+		} else {
+			$available_template = $default_template;
+		}
+
+	}elseif($is_archive){
+		$available_template = "archive/$archive_post_type";
+	}else{
+		$available_template = "single/$post_type";
 	}
 
 	if ($develop_preview) {


### PR DESCRIPTION
I've fixed the function with the assumption that the single/archive template in the templates folder of Gatsby exists.

Right now I can't add another check if the template exists because get_option('templates-collections') is just returning the templates which are also visible in the template dropdown.